### PR TITLE
Fix unbounded constraints in row layout

### DIFF
--- a/lib/withdrawal_options/withdrawal_options_widget.dart
+++ b/lib/withdrawal_options/withdrawal_options_widget.dart
@@ -63,9 +63,10 @@ class _WithdrawalOptionsWidgetState extends State<WithdrawalOptionsWidget> {
               Column(
                 mainAxisSize: MainAxisSize.max,
                 children: [
-                  Padding(
-                    padding: EdgeInsetsDirectional.fromSTEB(5.0, 5.0, 5.0, 5.0),
-                    child: Form(
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsetsDirectional.fromSTEB(5.0, 5.0, 5.0, 5.0),
+                      child: Form(
                       key: _model.formKey,
                       autovalidateMode: AutovalidateMode.disabled,
                       child: Padding(
@@ -356,6 +357,7 @@ class _WithdrawalOptionsWidgetState extends State<WithdrawalOptionsWidget> {
                               ),
                             ),
                           ],
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
Wrap the `Form` section in `withdrawal_options_widget.dart` with an `Expanded` widget to resolve unbounded width constraints in a nested `Row`.

The `Row` at `withdrawal_options_widget.dart:127` was throwing a `RenderFlex` error because it contained `Expanded` children but was itself within a parent that did not provide finite width constraints. Wrapping the `Padding` containing the `Form` with `Expanded` ensures this section receives bounded constraints, allowing the nested `Row` to lay out correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c71309a8-5fc1-4a68-9d9e-d36d14557912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c71309a8-5fc1-4a68-9d9e-d36d14557912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

