### PR TITLE
Fix withdrawal options model errors

### DIFF
--- a/lib/withdrawal_options/withdrawal_options_widget.dart
+++ b/lib/withdrawal_options/withdrawal_options_widget.dart
@@ -53,7 +53,7 @@ class _WithdrawalOptionsWidgetState extends State<WithdrawalOptionsWidget> {
           child: Column(
             mainAxisSize: MainAxisSize.max,
             children: [
-              wrapWithModel(
+              wrapWithModel<SingleAppbarModel>(
                 model: _model.singleAppbarModel,
                 updateCallback: () => safeSetState(() {}),
                 child: SingleAppbarWidget(


### PR DESCRIPTION
Add explicit type argument to `wrapWithModel` to fix a Flutter compilation error.

The error "Inferred type argument 'dynamic' doesn't conform to the bound 'FlutterFlowModel<Widget>' of the type variable 'T' on 'wrapWithModel'" occurred because the Dart compiler couldn't correctly infer the generic type for `wrapWithModel`. Explicitly specifying `<SingleAppbarModel>` resolves this type inference issue, allowing the application to compile.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f744aa6-ea9a-4c3a-bddd-07efedaccc76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f744aa6-ea9a-4c3a-bddd-07efedaccc76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

