### PR TITLE
Fix withdrawal options model errors

### DIFF
--- a/lib/withdrawal_options/withdrawal_options_widget.dart
+++ b/lib/withdrawal_options/withdrawal_options_widget.dart
@@ -53,7 +53,7 @@ class _WithdrawalOptionsWidgetState extends State<WithdrawalOptionsWidget> {
           child: Column(
             mainAxisSize: MainAxisSize.max,
             children: [
-              wrapWithModel(
+              wrapWithModel<SingleAppbarModel>(
                 model: _model.singleAppbarModel,
                 updateCallback: () => safeSetState(() {}),
                 child: SingleAppbarWidget(


### PR DESCRIPTION
Explicitly specify the generic type for `wrapWithModel` to resolve type inference errors.

The original errors regarding missing getters (`singleAppbarModel`, `formKey`) were cascading issues caused by Dart's inability to correctly infer the type for `wrapWithModel`. Providing the explicit type argument `<SingleAppbarModel>` allows the type system to correctly resolve the model and its properties, thereby eliminating the compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-85df3141-d625-41f0-ae2c-99496b985774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85df3141-d625-41f0-ae2c-99496b985774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

